### PR TITLE
Updates to support use of monochromatic bandpass as an array instead of a number, use of psf_offset in psf_offset to find_affine_parameters.find_rotation. Create output products by dividing data, model and residual by peak pixel of data.

### DIFF
--- a/notebooks/verify_rot.py
+++ b/notebooks/verify_rot.py
@@ -133,7 +133,7 @@ def rotsim_mir(rotdegs=0.0, ov=1):
 
     # create simdata and output observables directories data
     #
-    ov = 11 # oversampling for simulation of psf
+    ov = 1 # oversampling for simulation of psf
     fitsimdir = home+"/data/implaneia/niriss_verification/"
     if not os.path.exists(fitsimdir):  
         os.makedirs(fitsimdir) 
@@ -168,7 +168,7 @@ def rotsim_mir(rotdegs=0.0, ov=1):
     from nrm_analysis import find_affine2d_parameters as FAP
     mx, my, sx,sy, xo,yo, = (1.0,1.0, 0.0,0.0, 0.0,0.0)
     rotsearch_d = (8.0, 9.0, 10.0, 11.0, 12.0)
-    wave = 4.3e-6  # SI  - we won't know from the data what lam_c -  comes from outside?
+    wave = np.array([(1.0, 4.3e-6),])  # SI  - we won't know from the data what lam_c -  comes from outside?
                    # real-life - use apprpriate bandpass array
     aff_rot_measured = FAP.find_rotation(simdata, psf_offset,
                       rotsearch_d, mx, my, sx,sy, xo,yo,

--- a/nrm_analysis/find_affine2d_parameters.py
+++ b/nrm_analysis/find_affine2d_parameters.py
@@ -93,7 +93,7 @@ def find_scale(imagedata,
                        affine2d=aff)
         jw.set_pixelscale(pixel)
         jw.simulate(fov=npix, bandpass=bandpass, over=over)
-        psffn = psffmt.format(npix, holeshape, bandpass/um, scl)
+        psffn = psffmt.format(npix, holeshape, bandpass[:,1][0]/um, scl)
         if outdir: 
             fits.PrimaryHDU(data=jw.psf).writeto(outdir+"/"+psffn, overwrite=True)
             fits.writeto(psffn, jw.psf, overwrite=True)
@@ -149,7 +149,7 @@ def find_rotation(imagedata,
         # psf_offset in data coords & pixels.  Does it get rotated?  Second order errors poss.
         #  Some numerical testing needed for big eg 90 degree affine2d rotations.  Later.
         jw.simulate(fov=npix, bandpass=bandpass, over=over, psf_offset=psf_offset)
-        psffn = psffmt.format(npix, holeshape, bandpass/um, rot)
+        psffn = psffmt.format(npix, holeshape, bandpass[:,1][0]/um, rot)
         if outdir: 
             fits.PrimaryHDU(data=jw.psf).writeto(outdir+"/"+psffn, overwrite=True)
             fits.writeto(psffn, jw.psf, overwrite=True)
@@ -163,6 +163,12 @@ def find_rotation(imagedata,
 
     vprint("Debug: ", crosscorr_rots, rotdegs)
     rot_measured_d, max_cor = utils.findpeak_1d(crosscorr_rots, rotdegs)
+    #Machine noise residuals are obtained when rot_measured is forced to the exact value of simulated rotation (e.g. rot_measured=10.00 and max_cor is forced to 1.0)
+    #When rot_measured=10.000000000958407 and max_cor=0.9999999999999998 instead of 10.00 and 1.00 the model is created at a different visible rotation.
+    #A very small difference between simulated and measured rotation and between max_cor of 1 and calculated value creates the model at a different rotation compared to the data.
+    #For 10 degree pupil rotation, model residuals in the fit are ~1e-5 contrast or the peak at bright snowflake points, but much smaller within few resolution elements of the PSF center.
+    #This may be improved by treating possibly non-commuting psf_offsets and rotation (after delivery to the pipeline in April 2020).
+
     vprint("Rotation measured: max correlation {1:.3e}", rot_measured_d, max_cor)
 
     # return convenient affine2d

--- a/nrm_analysis/fringefitting/LG_Model.py
+++ b/nrm_analysis/fringefitting/LG_Model.py
@@ -317,19 +317,11 @@ class NRM_Model():
         self.simhdr["psfoff0"] = (psf_offset[0], "psf ctr at arrayctr + off[0], detpix") # user-specified
         self.simhdr["psfoff1"] = (psf_offset[1], "psf ctr at arrayctr + off[1], detpix") # user-specified
 
-        # Monochromatic and polychromatic cases done with same loop:
-        if hasattr(self.bandpass, '__iter__') == False:
-            vprint("Got one wavelength. Simulating monochromatic ... ")
-            simbandpass = [(1.0, bandpass)]
-        else:
-            self.logger.debug("------Simulating Polychromatic------")
-            simbandpass = bandpass
-
         self.psf_over = np.zeros((over*fov, over*fov))
         nspec = 0
         # accumulate polychromatic oversampled psf in the object
         vprint("**** simulate():  psf_offset {0}".format(psf_offset))
-        for w,l in simbandpass: # w: wavelength's weight, l: lambda (wavelength)
+        for w,l in bandpass: # w: wavelength's weight, l: lambda (wavelength)
             vprint("weight:", w, "wavelength:", l)
             vprint("fov/detector pixels:", fov)
             vprint("over:", over)
@@ -384,14 +376,6 @@ class NRM_Model():
 
         self.modelctrs = self.ctrs
 
-        # Monochromatic and polychromatic cases done with same loop:
-        if hasattr(self.bandpass, '__iter__') == False:
-            vprint("Got one wavelength. Simulating monochromatic ... ")
-            simbandpass = [(1.0, bandpass)]
-        else:
-            self.logger.debug("------Simulating Polychromatic------")
-            simbandpass = bandpass
-
         # The model shape is (fov) x (fov) x (# solution coefficients)
         # the coefficient refers to the terms in the analytic equation
         # There are N(N-1) independent pistons, double-counted by cosine
@@ -400,7 +384,7 @@ class NRM_Model():
         self.model = np.zeros((self.fov, self.fov, self.N*(self.N-1)+2))
         self.model_beam = np.zeros((self.over*self.fov, self.over*self.fov))
         self.fringes = np.zeros((self.N*(self.N-1)+1, self.over*self.fov, self.over*self.fov))
-        for w,l in simbandpass: # w: weight, l: lambda (wavelength)
+        for w,l in bandpass: # w: weight, l: lambda (wavelength)
             vprint("weight: {0}, lambda: {1}".format(w,l))
             # model_array returns the envelope and fringe model (a list of oversampled fov x fov slices)
             pb, ff = analyticnrm2.model_array(self.modelctrs, l, self.over,

--- a/nrm_analysis/misctools/utils.py
+++ b/nrm_analysis/misctools/utils.py
@@ -1085,6 +1085,7 @@ def quadratic_extremum(p):  # used to take an x vector and return y,x for smoot 
     print("Max y value %.5f"%(-p[1]*p[1] /(4.0*p[0]) + p[2]))
     print("occurs at x = %.5f"%(-p[1]/(2.0*p[0])))
     #return -p[1]/(2.0*p[0]), -p[1]*p[1] /(4.0*p[0]) + p[2], p[0]*x*x + p[1]*x + p[2]
+    print("x and y from utils.quadratic_extremum",-p[1]/(2.0*p[0]), -p[1]*p[1] /(4.0*p[0]) + p[2])
     return -p[1]/(2.0*p[0]), -p[1]*p[1] /(4.0*p[0]) + p[2]
 
 

--- a/nrm_analysis/nrm_core.py
+++ b/nrm_analysis/nrm_core.py
@@ -162,10 +162,16 @@ class FringeFitter:
 
     def save_output(self, slc, nrm):
         # cropped & centered PSF
+        datapeak = self.ctrd.max()
+        #TBD: Keep only n_*.fits files after testing is done and before doing ImPlaneIA delivery
         if self.save_txt_only==False:
             fits.PrimaryHDU(data=self.ctrd, \
                     header=self.scihdr).writeto(self.savedir+\
                     self.sub_dir_str+"/centered_{0}.fits".format(slc), \
+                    overwrite=True)
+            fits.PrimaryHDU(data=self.ctrd/datapeak, \
+                    header=self.scihdr).writeto(self.savedir+\
+                    self.sub_dir_str+"/n_centered_{0}.fits".format(slc), \
                     overwrite=True)
 
             model, modelhdu = nrm.plot_model(fits_true=1)
@@ -173,9 +179,16 @@ class FringeFitter:
             fits.PrimaryHDU(data=nrm.residual).writeto(self.savedir+\
                         self.sub_dir_str+"/residual_{0:02d}.fits".format(slc), \
                         overwrite=True)
+            fits.PrimaryHDU(data=nrm.residual/datapeak).writeto(self.savedir+\
+                        self.sub_dir_str+"/n_residual_{0:02d}.fits".format(slc), \
+                        overwrite=True)
             modelhdu.writeto(self.savedir+\
                         self.sub_dir_str+"/modelsolution_{0:02d}.fits".format(slc),\
                         overwrite=True)
+            fits.PrimaryHDU(data=model/datapeak, \
+                    header=modelhdu.header).writeto(self.savedir+\
+                    self.sub_dir_str+"/n_modelsolution_{0:02d}.fits".format(slc), \
+                    overwrite=True)
         else:
             print("NOT SAVING ANY FITS FILES. SET save_txt_only=False TO SAVE.")
 
@@ -238,7 +251,6 @@ def fit_fringes_parallel(args, threads):
     filename = args['file']
     id_tag = args['id']
     self.prihdr, self.scihdr, self.scidata = self.instrument_data.read_data(filename)
-
     self.sub_dir_str = self.instrument_data.sub_dir_str
     try:
         os.mkdir(self.savedir+self.sub_dir_str)

--- a/nrm_analysis/tests/test_affine2d_makemodel_rot.py
+++ b/nrm_analysis/tests/test_affine2d_makemodel_rot.py
@@ -67,7 +67,7 @@ class Affine2dMakeModelRotTestCase(unittest.TestCase):
         self.fmt = "    ({0:+.3f}, {1:+.3f}) -> ({2:+.3f}, {3:+.3f})"
         self.pixel = 0.0656 
         self.npix = 87
-        self.wave = 4.3e-6 # m
+        self.wave = np.array([(1.0, 4.3e-6),]) # m
         self.over = 11
 
 
@@ -101,7 +101,7 @@ class Affine2dMakeModelRotTestCase(unittest.TestCase):
                              over=self.over)
             # write psf
             psffn = self.fnfmt.format(self.npix, self.holeshape,
-                                      self.wave/um, rot, self.hstr)
+                                      self.wave[:,1][0]/um, rot, self.hstr)
             fits.writeto(psffn, self.jw.psf, overwrite=True)
             header = fits.getheader(psffn)
             header = affinepars2header(header, aff)

--- a/nrm_analysis/tests/test_affine2d_rot_psf.py
+++ b/nrm_analysis/tests/test_affine2d_rot_psf.py
@@ -48,7 +48,7 @@ class Affine2dTestCase(unittest.TestCase):
         self.fmt = "    ({0:+.3f}, {1:+.3f}) -> ({2:+.3f}, {3:+.3f})"
         self.pixel = 0.0656 *  u.arcsec.to(u.rad)
         self.npix = 87
-        self.wave = 4.3e-6 # m
+        self.wave = np.array([(1.0, 4.3e-6),]) # m
         self.over = 1
 
         mx, my = 1.0, 1.0
@@ -74,7 +74,7 @@ class Affine2dTestCase(unittest.TestCase):
             self.jw = NRM_Model(mask='jwst', holeshape="hexonly", affine2d=aff)
             self.jw.set_pixelscale(self.pixel*arcsec2rad)
             self.jw.simulate(fov=self.npix, bandpass=self.wave, over=self.over)
-            psffn = self.fnfmt.format(self.npix, 'hexonly', self.wave/um, rot)
+            psffn = self.fnfmt.format(self.npix, 'hexonly', self.wave[:,1][0]/um, rot)
             fits.writeto(psffn, self.jw.psf, overwrite=True)
             header = fits.getheader(psffn)
             header = affinepars2header(header, aff)
@@ -94,13 +94,13 @@ class Affine2dTestCase(unittest.TestCase):
             The file names are hand-edited to reflect the oversampling and rotations,
             so this is more a sanity check and code development tool than a routine test.
         """
-        psf0  = fits.getdata(self.fnfmt.format(self.npix, 'hexonly', self.wave/um, 0))
-        psf90 = fits.getdata(self.fnfmt.format(self.npix, 'hexonly', self.wave/um, 90))
+        psf0  = fits.getdata(self.fnfmt.format(self.npix, 'hexonly', self.wave[:,1][0]/um, 0))
+        psf90 = fits.getdata(self.fnfmt.format(self.npix, 'hexonly', self.wave[:,1][0]/um, 90))
         psf90r0 = np.rot90(psf90)
         psfdiff = psf0 - psf90r0
         fits.PrimaryHDU(data=psfdiff).writeto(self.data_dir+"/diff_90_0_off08_ov1.fits", overwrite=True)
-        psf0  = fits.getdata(self.fnfmt.format(self.npix, 'hexonly', self.wave/um, 5))
-        psf90 = fits.getdata(self.fnfmt.format(self.npix, 'hexonly', self.wave/um, 95))
+        psf0  = fits.getdata(self.fnfmt.format(self.npix, 'hexonly', self.wave[:,1][0]/um, 5))
+        psf90 = fits.getdata(self.fnfmt.format(self.npix, 'hexonly', self.wave[:,1][0]/um, 95))
         psf90r0 = np.rot90(psf90)
         psfdiff = psf0 - psf90r0
         fits.PrimaryHDU(data=psfdiff).writeto(self.data_dir+"/diff_95_5_off08_ov1.fits", overwrite=True)

--- a/nrm_analysis/tests/test_affine2d_xyscale_psf.py
+++ b/nrm_analysis/tests/test_affine2d_xyscale_psf.py
@@ -46,7 +46,7 @@ class Affine2dTestCase(unittest.TestCase):
 
         self.pixel = 0.0656 *  u.arcsec.to(u.rad)
         self.npix = 87
-        self.wave = 4.3e-6 # m
+        self.wave = np.array([(1.0, 4.3e-6),])# m
         self.over = 1
 
         ################
@@ -78,7 +78,7 @@ class Affine2dTestCase(unittest.TestCase):
             self.jw = NRM_Model(mask='jwst', holeshape="circ", affine2d=aff)
             self.jw.set_pixelscale(self.pixel)
             self.jw.simulate(fov=self.npix, bandpass=self.wave, over=self.over)
-            psffn = self.fnfmt.format(self.npix, 'circ', self.wave/um, aff.name)
+            psffn = self.fnfmt.format(self.npix, 'circ', self.wave[:,1][0]/um, aff.name)
             fits.writeto(psffn, self.jw.psf, overwrite=True)
             header = fits.getheader(psffn)
             header = affinepars2header(header, aff)
@@ -89,7 +89,7 @@ class Affine2dTestCase(unittest.TestCase):
             self.jw = NRM_Model(mask='jwst', holeshape="circonly", affine2d=aff)
             self.jw.set_pixelscale(self.pixel)
             self.jw.simulate(fov=self.npix, bandpass=self.wave, over=self.over)
-            psffn = self.fnfmt.format(self.npix, 'circonly', self.wave/um, aff.name)
+            psffn = self.fnfmt.format(self.npix, 'circonly', self.wave[:,1][0]/um, aff.name)
             fits.writeto(psffn, self.jw.psf, overwrite=True)
             header = fits.getheader(psffn)
             header = affinepars2header(header, aff)
@@ -100,7 +100,7 @@ class Affine2dTestCase(unittest.TestCase):
             self.jw = NRM_Model(mask='jwst', holeshape="hex", affine2d=aff)
             self.jw.set_pixelscale(self.pixel)
             self.jw.simulate(fov=self.npix, bandpass=self.wave, over=self.over)
-            psffn = self.fnfmt.format(self.npix, 'hex', self.wave/um, aff.name)
+            psffn = self.fnfmt.format(self.npix, 'hex', self.wave[:,1][0]/um, aff.name)
             fits.writeto(psffn, self.jw.psf, overwrite=True)
             header = fits.getheader(psffn)
             header = affinepars2header(header, aff)
@@ -111,7 +111,7 @@ class Affine2dTestCase(unittest.TestCase):
             self.jw = NRM_Model(mask='jwst', holeshape="hexonly", affine2d=aff)
             self.jw.set_pixelscale(self.pixel)
             self.jw.simulate(fov=self.npix, bandpass=self.wave, over=self.over)
-            psffn = self.fnfmt.format(self.npix, 'hexonly', self.wave/um, aff.name)
+            psffn = self.fnfmt.format(self.npix, 'hexonly', self.wave[:,1][0]/um, aff.name)
             fits.writeto(psffn, self.jw.psf, overwrite=True)
             header = fits.getheader(psffn)
             header = affinepars2header(header, aff)
@@ -122,7 +122,7 @@ class Affine2dTestCase(unittest.TestCase):
             self.jw = NRM_Model(mask='jwst', holeshape="fringeonly", affine2d=aff)
             self.jw.set_pixelscale(self.pixel)
             self.jw.simulate(fov=self.npix, bandpass=self.wave, over=self.over)
-            psffn = self.fnfmt.format(self.npix, 'fringeonly', self.wave/um, aff.name)
+            psffn = self.fnfmt.format(self.npix, 'fringeonly', self.wave[:,1][0]/um, aff.name)
             fits.writeto(psffn, self.jw.psf, overwrite=True)
             header = fits.getheader(psffn)
             header = affinepars2header(header, aff)
@@ -140,8 +140,8 @@ class Affine2dTestCase(unittest.TestCase):
 
     """  Ideal and Xreverse_xflipped should be machine zero or close """
     def eval_psf_hex(self):
-        psfIdeal  = fits.getdata(self.fnfmt.format(self.npix, 'hex', self.wave/um, "Ideal"))
-        psfXrev  = fits.getdata(self.fnfmt.format(self.npix, 'hex', self.wave/um, "Xreverse"))
+        psfIdeal  = fits.getdata(self.fnfmt.format(self.npix, 'hex', self.wave[:,1][0]/um, "Ideal"))
+        psfXrev  = fits.getdata(self.fnfmt.format(self.npix, 'hex', self.wave[:,1][0]/um, "Xreverse"))
         psfdiff = psfIdeal - psfXrev[::-1,:]
         print("    Numerical Summary:         hex  psf: " +\
               self.numtestfmt.format(psfIdeal.min(), psfIdeal.max(), psfIdeal.mean(), psfIdeal.std()))
@@ -151,8 +151,8 @@ class Affine2dTestCase(unittest.TestCase):
         return psfdiff.std()
 
     def eval_psf_fringeonly(self):
-        psfIdeal  = fits.getdata(self.fnfmt.format(self.npix, 'fringeonly', self.wave/um, "Ideal"))
-        psfXrev  = fits.getdata(self.fnfmt.format(self.npix, 'fringeonly', self.wave/um, "Xreverse"))
+        psfIdeal  = fits.getdata(self.fnfmt.format(self.npix, 'fringeonly', self.wave[:,1][0]/um, "Ideal"))
+        psfXrev  = fits.getdata(self.fnfmt.format(self.npix, 'fringeonly', self.wave[:,1][0]/um, "Xreverse"))
         psfdiff = psfIdeal - psfXrev[::-1,:]
         print("    Numerical Summary:  fringeonly  psf: " +\
               self.numtestfmt.format(psfIdeal.min(), psfIdeal.max(), psfIdeal.mean(), psfIdeal.std()))
@@ -162,8 +162,8 @@ class Affine2dTestCase(unittest.TestCase):
         return psfdiff.std()
 
     def eval_psf_hexonly(self):
-        psfIdeal  = fits.getdata(self.fnfmt.format(self.npix, 'hexonly', self.wave/um, "Ideal"))
-        psfXrev  = fits.getdata(self.fnfmt.format(self.npix, 'hexonly', self.wave/um, "Xreverse"))
+        psfIdeal  = fits.getdata(self.fnfmt.format(self.npix, 'hexonly', self.wave[:,1][0]/um, "Ideal"))
+        psfXrev  = fits.getdata(self.fnfmt.format(self.npix, 'hexonly', self.wave[:,1][0]/um, "Xreverse"))
         psfdiff = psfIdeal - psfXrev[::-1,:]
         print("    Numerical Summary:     hexonly  psf: " +\
               self.numtestfmt.format(psfIdeal.min(), psfIdeal.max(), psfIdeal.mean(), psfIdeal.std()))

--- a/nrm_analysis/tests/test_find_affine2d_parameters.py
+++ b/nrm_analysis/tests/test_find_affine2d_parameters.py
@@ -39,7 +39,7 @@ class Affine2dRotTestCase(unittest.TestCase):
 
         pixel = 0.0656 *  u.arcsec.to(u.rad)
         npix = 87
-        wave = 4.3e-6 # m
+        wave = np.array([(1.0, 4.3e-6),]) # m
         over = 3
         holeshape='hex'
         
@@ -60,10 +60,10 @@ class Affine2dRotTestCase(unittest.TestCase):
         imagedata = jw.psf.copy()
         del jw
         fits.getdata(imagefn)
-
+        psf_offset = (0.0,0.0)
         print("driver:", rotdegs)
         mx, my, sx,sy, xo,yo, = (1.0,1.0, 0.0,0.0, 0.0,0.0)
-        aff_best_rot =FAP.find_rotation(imagedata,
+        aff_best_rot =FAP.find_rotation(imagedata,psf_offset,
                                         rotdegs, mx, my, sx,sy, xo,yo,
                                         pixel, npix, wave, over, holeshape, outdir=data_dir)
 

--- a/nrm_analysis/tests/test_find_pass_affine.py
+++ b/nrm_analysis/tests/test_find_pass_affine.py
@@ -45,7 +45,7 @@ class FindPassAffine2dTestCase(unittest.TestCase):
         verbose = 1
         overwrite = 1
 
-        monochromatic_wavelength_m = 4.3e-6 
+        monochromatic_wavelength_m = np.array([(1.0, 4.3e-6),]) 
         mask = 'MASK_NRM'
         filter = 'F430M'
         pixel = 0.0656  # arcsec
@@ -120,9 +120,10 @@ class FindPassAffine2dTestCase(unittest.TestCase):
         print("driver rotd_search:", rotd_search)
         print("driver rotd_true:", rotd_true)
         mx, my, sx,sy, xo,yo, = (1.0,1.0, 0.0,0.0, 0.0,0.0)
+        psf_offset = (0.0,0.0)
 
         # FIND ROTATION FROM IMAGE DATA CREATED USING KNOWN ROTATION AND SCALE
-        aff_best_rot = FAP.find_rotation(self.simulated_image,
+        aff_best_rot = FAP.find_rotation(self.simulated_image,psf_offset,
                                          rotd_search, mx, my, sx,sy, xo,yo,
                                          header['PIXELSCL']*arcsec2rad, 
                                          n_image, self.monochromatic_wavelength_m, oversample, holeshape, 

--- a/nrm_analysis/tests/test_fringe_fitting.py
+++ b/nrm_analysis/tests/test_fringe_fitting.py
@@ -38,7 +38,7 @@ class FringeFittingTestCase(unittest.TestCase):
         verbose = 1
         overwrite = 1
 
-        monochromatic_wavelength_m = 4.3e-6 
+        monochromatic_wavelength_m = np.array([(1.0, 4.3e-6),])
         mask = 'MASK_NRM'
         filter = 'F430M'
         pixelscale_arcsec = 0.0656 

--- a/nrm_analysis/tests/test_psf_offset.py
+++ b/nrm_analysis/tests/test_psf_offset.py
@@ -35,7 +35,7 @@ class PSFoffsetTestCase(unittest.TestCase):
 
         self.pixel = 0.0656 *  u.arcsec.to(u.rad)
         self.npix = 87
-        self.wave = 4.3e-6 # m
+        self.wave = np.array([(1.0, 4.3e-6),])  # m
         self.over = 1
 
         """
@@ -53,7 +53,7 @@ class PSFoffsetTestCase(unittest.TestCase):
         print("\n\t*** Watch out *** if comparing to real data: slightly finer-than-actual-detector sampling used for clearer images\n")
         fov = 101 # 'detpix' but at finer sampling than actual
         over=1
-        wav_m = 4.3e-6 
+        wav_m = np.array([(1.0, 4.3e-6),]) 
         filt = 'F430M'
         band = 'Monochromatic '+np.str(wav_m)
 
@@ -85,7 +85,7 @@ class PSFoffsetTestCase(unittest.TestCase):
             header['SEGNAMES'] = "asbuilt"
             header['PIXELSCL'] = pixel_as
             header['over'] = over
-            header['FILTER'] = wav_m
+            header['FILTER'] = wav_m[0][1]
             header['hole'] = holeshape 
             header['PUPIL'] =  'asbuilt'
             header['psfoff0'] =  (psfo[0], "ds9X / detector pixels")


### PR DESCRIPTION
1. test_find_pass_affine.py and test_fringe_fitting.py crash at InstrumentData.py line 498: in read_data.
2. centered data, modelsolution*fits and residual*fit can be deleted later. Temporarily keeping these files during testing.