### PR TITLE
Updated driver with software verification, seperated psf offsets used for finding rotation and for fringefitting.

### DIFF
--- a/notebooks/implaneia_driver.py
+++ b/notebooks/implaneia_driver.py
@@ -2,30 +2,26 @@
 
 import os
 import numpy as np
+import scipy
 from astropy.io import fits
 from astropy import units as u
 import sys
 import string
+import nrm_analysis
 from nrm_analysis.fringefitting.LG_Model import NRM_Model
 from nrm_analysis.misctools import utils  
-from nrm_analysis.misctools.utils import mas2rad, amisim2mirage
 from nrm_analysis import nrm_core, InstrumentData
+from nrm_analysis import find_affine2d_parameters as FAP
 from pathlib import Path
-from nrm_analysis.misctools.utils import avoidhexsingularity
 from nrm_analysis.misctools.utils import Affine2d
 
 
+np.set_printoptions(precision=4, linewidth=160)
 
-
-np.set_printoptions(precision=6,linewidth=160)
 home = os.path.expanduser('~')
 fitsimdir = home+"/data/implaneia/niriss_verification/test_all_residuals/"
 if not os.path.exists(fitsimdir):  
     os.makedirs(fitsimdir)
-
-tr = "all_effects_data_mir"
-test_tar = fitsimdir + tr + ".fits"
-
 
 #mirexample = os.path.expanduser('~') + \
 #        "/gitsrc/ImPlaneIA/example_data/example_niriss/" + \
@@ -34,198 +30,194 @@ mirexample = os.path.expanduser('~') + \
          "/ImplaneIA/notebooks/simulatedpsfs/" + \
          "jw00793001001_01101_00001_nis_cal.fits"
 
-fov = 80
+fov = 79
 filt="F430M"
+lamc = 4.3e-6
 oversample=11
-bandpass = np.array([(1.0, 4.3e-6),])
+bandpass = np.array([(1.0, lamc),])
 
+pixelscale_as=0.0656
+arcsec2rad = u.arcsec.to(u.rad)
+PIXELSCALE_r =  pixelscale_as * arcsec2rad
+holeshape='hex'
 
-datafiles = (fitsimdir+'all_effects_data_mir.fits',)# all_effects_data_mir_copy.fits""").split()
+datafiles = (fitsimdir+'all_effects_data_mir.fits',)
 np.random.seed(100)
-#datafiles=['all_effects_data_mir.fits','all_effects_data_mir_copy.fits']
+
+def default_printoptions():
+    np.set_printoptions(edgeitems=3, infstr='inf', linewidth=75, nanstr='nan', precision=8,
+    suppress=False, threshold=1000, formatter=None)
+
+def cp_var(nh, cps):
+    """ True standard deviation given non-independent closure phases """
+    return  ((cps - cps.mean())**2).sum() / scipy.special.comb(nh-1,2)
+def ca_var(nh, cas):
+    """ True standard deviation given non-independent closure amplitudes """
+    return  ((cas - cas.mean())**2).sum() / scipy.special.comb(nh-3, 2)
+
+def examine_residuals(ff, trim=36):
+    """ input: FringeFitter instance after fringes are fit """
+
+    print("\n\texamine_residuals: FIT QUALITY:")
+    print(" Standard deviation & variance take into acount reduced DOF of all CP's and CAs")
+    print("   Closure phase mean {:+.4f}  std dev {:.2e}  var {:.2e}".format(ff.nrm.redundant_cps.mean(),
+                                                  np.sqrt(cp_var(ff.nrm.N,ff.nrm.redundant_cps)),
+                                                         cp_var(ff.nrm.N, ff.nrm.redundant_cps)))
+    print("   Closure ampl  mean {:+.4f}  std dev {:.2e}  var {:.2e}".format(ff.nrm.redundant_cas.mean(),
+                                                  np.sqrt(cp_var(ff.nrm.N,ff.nrm.redundant_cas)),
+                                                         cp_var(ff.nrm.N, ff.nrm.redundant_cas)))
+
+    np.set_printoptions(precision=3, formatter={'float': lambda x: '{:+.1e}'.format(x)}, linewidth=80)
+    print(" Normalized residuals trimmed by {:d} pixels from each edge".format(trim))
+    print((ff.nrm.residual/ff.datapeak)[trim:-trim,trim:-trim])
+    print(" Normalized residuals max and min: {:.2e}, {:.2e}".format( ff.nrm.residual.max() / ff.datapeak,
+                                                                      ff.nrm.residual.min() / ff.datapeak))
+    default_printoptions()
 
 
-def simulate_data(rot_deg=0.0, psf_offsets_det = (0.0,0.0), phi_waves = np.zeros((7,))):
+    
+def analyze_data(fitsfn, test, affine2d=None, psf_offset_find_rotation = (0.0,0.0), psf_offset_ff = None, rotsearch_d=None, set_pistons=None):
+    """ returns: affine2d (measured or input), psf_offset_find_rotation (input), psf_offset_ff (input or found), fringe pistons/r (found)
+        Test data analysis using different sets of parameters
+
+        If using only one set of parameters define the function as:
+        def analyze_data(fitsfn, affine2d=None, psf_offset_find_rotation = (0.0,0.0), psf_offset_ff = None, rotsearch_d=None, set_pistons=None):
+
+        and call as:
+    
+        for df in datafiles:
+        print("__main__: ")
+        np.set_printoptions(formatter={'float': lambda x: '{:+.2e}'.format(x)}, linewidth=80)
+        print("           analyzing", df)
+        datafile = fits.getdata(df)
+        _aff, _psf_offset_r, _psf_offset_ff, fringepistons = analyze_data(df, affine2d=None,
+                                                      psf_offset_find_rotation = (0.0,0.0), psf_offset_ff = None,
+                                                      rotsearch_d=_rotsearch_d)
     """
-    This function should not be a part of the calwebb_ami3 pipeline. It is used to simulate data for ImPlaneIA testing and verification.
-    """
-    pixelscale_as=0.0656
-    arcsec2rad = u.arcsec.to(u.rad)
-    PIXELSCALE_r =  pixelscale_as * arcsec2rad
-    holeshape='hex'
 
-    #*************ADD ROTATION TO PERFECT DATA***********************************************
+    print("analyze_data: input file", fitsfn, end="")
     
-    rot = avoidhexsingularity(rot_deg) # in utils
-    affine_rot = Affine2d(rotradccw=np.pi*rot/180.0, name="{0:.0f}".format(rot)) # in utils
-    aff = affine_rot
-    print("***********simulated aff**************")
-    aff.show()
-    
-    #*************ADD OFFSETS TO PERFECT DATA************************************************
-    """
-    Use psf_offset from the function call
-    """
-    #************ADD PISTONS TO PERFECT DATA************************************************
+    data = fits.getdata(fitsfn)
+    dim = data.shape[1]
 
-    #lambda/14 ~ 80% strehl ratio
-    #Doing tests with phi = 0.5*np.random.normal(0,1.0, 7) / 14.0 in the function call# waves
-    
-    phi = phi_waves - phi_waves.mean()
-    print("phi", phi, "varphi", phi.var(), "waves")
-    
-    print("phi_nb stdev/w", phi.std())
-    print("phi_nb stdev/r", phi.std()*2*np.pi)
-    print("phi_nb mean/r", phi.mean()*2*np.pi)
-
-    pistons = phi *4.3e-6   #meters
-    #Temporarily overwrite with smaller pistons measured from CV3 data by un-commenting the line below.
-    #pistons = np.array([5.25e-13, -2.054e-13, -4.300e-14, -2.38e-13,6.21e-15, -2.036e-13,  1.60e-13])  #meters. too small
-
-    print("/=====input pistons/m=======/\n",pistons)
-    print("/=====input pistons/r=======/\n",pistons*(2*np.pi)/4.3e-6)
-    
-
-    #***********ADD ALL EFFECTS TO SIMULATE**************************************************
-    jw = NRM_Model(mask='jwst', holeshape="hex", affine2d=aff)
-    jw.set_pixelscale(pixelscale_as*arcsec2rad)
-    jw.set_pistons(pistons)
-    jw.simulate(fov=fov, bandpass=bandpass, over=oversample,psf_offset=psf_offsets_det)
-    fits.PrimaryHDU(data=jw.psf).writeto(fitsimdir+"all_effects_data.fits",overwrite=True)
-
-    #**********Convert simulated data to mirage format.***************************************
-
-    amisim2mirage( fitsimdir, ("all_effects_data",), mirexample, filt)
-    return aff, psf_offsets_det, pistons,
-
-    
-def analyze_data(test_tar, affine2d = None, psf_offset_find_rotation = (0.0,0.0), psf_offset_ff = None, rotsearch_d = None, set_pistons = None):
-    """
-    This function can be used for analyzing any NIRISS AMI data in MIRAGE format. Use this for ami_analyze part of the calwebb_ami3 pipeline.
-    """
-    pixelscale_as=0.0656
-    arcsec2rad = u.arcsec.to(u.rad)
-    PIXELSCALE_r =  pixelscale_as * arcsec2rad
-    holeshape='hex'
-    print(test_tar)
-    
-    data = fits.getdata(test_tar)
-    print(data.shape[1])
-    dim = data.shape[1]       #Do not use 'fov' for parameter name. It's specific to the simulation which we may or may not do.
-
-    from nrm_analysis import find_affine2d_parameters as FAP
     mx, my, sx,sy, xo,yo, = (1.0,1.0, 0.0,0.0, 0.0,0.0)
-    
-    psf_offset = psf_offset_find_rotation
 
     if affine2d is None:
-        print("Finding affine2d...")
-        affine2d = FAP.find_rotation(data[0,:,:], psf_offset,
+        print(" analyze_data: Finding affine2d...")
+        affine2d = FAP.find_rotation(data[0,:,:], psf_offset_find_rotation,
                       rotsearch_d, mx, my, sx, sy, xo,yo,
                       PIXELSCALE_r, dim, bandpass, oversample, holeshape, outdir=fitsimdir)
-        print("***** Using measured affine2d *****")
+        print("analyze_data:  Using measured affine2d...", affine2d.name)
     else:
-        affine2d = aff
-        print("***** Using affine2d created with user supplied rotation *****")
-    affine2d.show()
+        print("analyze_data:  Using incoming affine2d ", affine2d.name)
 
-    niriss = InstrumentData.NIRISS(filt,bandpass=bandpass,affine2d=affine2d)
-    ff_t = nrm_core.FringeFitter(niriss, psf_offset_ff=psf_offset_ff, datadir=fitsimdir, savedir=fitsimdir,
+    niriss = InstrumentData.NIRISS(filt, bandpass=bandpass, affine2d=affine2d)
+    ff_t = nrm_core.FringeFitter(niriss, psf_offset_ff=psf_offset_ff, datadir=fitsimdir, savedir=fitsimdir+"test%d/" % (test),
                                  oversample=oversample, interactive=False)
+
+    ff_t.fit_fringes(fitsfn)
+    examine_residuals(ff_t)
+
+    np.set_printoptions(formatter={'float': lambda x: '{:+.2e}'.format(x)}, linewidth=80)
+    print("analyze_data: fringepistons/rad", ff_t.nrm.fringepistons)
+    default_printoptions()
+    return affine2d, psf_offset_find_rotation, ff_t.nrm.bestcenter, ff_t.nrm.fringepistons
+
     
-    print(test_tar)
-    ff_t.fit_fringes(test_tar)
+def simulate_data(affine2d=None, psf_offset_det=None, pistons_w=None):
 
-    data=fits.getdata(test_tar)
+    print(" simulate_data: ", affine2d.name)
 
-    n_residual_max = (ff_t.nrm.residual/data.max()).max()
-    n_residual_min = (ff_t.nrm.residual/data.max()).min()
+    #************ADD PISTONS TO PERFECT DATA******************
+    pistons_w = pistons_w - pistons_w.mean()
+    pistons_m =  pistons_w * lamc
+    pistons_r =  pistons_w * 2.0 * np.pi
 
-    print("***** Mean CP ",ff_t.nrm.redundant_cps.mean(), " *****")
-    print("***** Sigma CP ",ff_t.nrm.redundant_cps.std(), " *****")
+    utils.show_pistons_w(pistons_w, str="simulate_data: input pistons")
 
-    pos = np.get_printoptions()
-    np.set_printoptions(precision=3, formatter={'float': lambda x: '{:+.3e}'.format(x)},
-                            linewidth=80)
-    print("***** n_residual[36:-36,36:-36] *****")
-    print((ff_t.nrm.residual/data.max())[36:-36,36:-36])
-    print("***** n_residual_max ", n_residual_max, " *****")
-    print("***** n_residual_min ", n_residual_min, " *****")
+    np.set_printoptions(precision=4, formatter={'float': lambda x: '{:+.1e}'.format(x)}, linewidth=80)
+    print(" simulate_data: pistons_um", pistons_m/1e-6)
+    print(" simulate_data: pistons_r", pistons_r)
+    print(" simulate_data: pistons_w stdev/w", round(pistons_w.std(),4))
+    print(" simulate_data: pistons_w stdev/r", round(pistons_w.std()*2*np.pi,4))
+    print(" simulate_data: pistons_w mean/r",  round(pistons_w.mean()*2*np.pi,4))
+    default_printoptions()
 
-    return affine2d, ff_t.nrm.bestcenter,  psf_offset, ff_t.nrm.fringepistons,
-    print("done")
-    np.set_printoptions(pos)
-    
-    
+
+    #***********ADD EFFECTS TO SIMULATE*******************
+    jw = NRM_Model(mask='jwst', holeshape="hex", affine2d=affine2d)
+    jw.set_pixelscale(pixelscale_as*arcsec2rad)
+    jw.set_pistons(pistons_m)
+    print(" simulate: ", psf_offset_det, type(psf_offset_det))
+    jw.simulate(fov=fov, bandpass=bandpass, over=oversample, psf_offset=psf_offset_det )
+    fits.PrimaryHDU(data=jw.psf).writeto(fitsimdir+"all_effects_data.fits",overwrite=True)
+
+    #**********Convert simulated data to mirage format.*******
+    utils.amisim2mirage(fitsimdir, ("all_effects_data",), mirexample, filt)
+
 
 if __name__ == "__main__":
 
+    identity = utils.Affine2d(rotradccw=utils.avoidhexsingularity(0.0),
+                              name="affrot_{0:+.3f}deg".format(0.0))
+    no_pistons = np.zeros((7,)) * 1.0
+    _psf_offset_det = (0.48, 0.0)
+    no_psf_offset = (0.0, 0.0)
+
     rot = 2.0
-    rot = avoidhexsingularity(rot) # in utils
-    aff = Affine2d(rotradccw=np.pi*rot/180.0, name="{0:.0f}".format(rot)) # in utils
-    _rotsearch_d = (-3.00, -2.00,-1.0,0.0,1.0,2.0, 3.0,4.0, 5.0, 6.0)
+    rot = utils.avoidhexsingularity(rot) # in utils
+    aff = utils.Affine2d(rotradccw=np.pi*rot/180.0, name="{0:.0f}".format(rot)) # in utils
+    _rotsearch_d = (-3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0)
+    _rotsearch_d = np.arange(-3, 3.1, 1)
 
-    #Uncomment to create one of the simulations below
-    #affine2d_in,psf_offsets_in,pistons_in = simulate_data(rot_deg=rot,psf_offsets_det= (0.0,0.0))                                                  # perfect data when rot =0.0
-    #affine2d_in,psf_offsets_in,pistons_in = simulate_data(rot_deg=rot,psf_offsets_det= (0.48,0.0))                                                 # a. rotation (zero on non-zero defined by rot), non zero psf_offsets, zero pistons
-    #affine2d_in,psf_offsets_in,pistons_in = simulate_data(rot_deg=rot,psf_offsets_det= (0.0,0.0), phi_waves=0.5*np.random.normal(0,1.0, 7)/14.0)   # b. rotation (zero on non-zero defined by rot),no psf_offsets, non-zero pistons
-    affine2d_in,psf_offsets_in,pistons_in = simulate_data(rot_deg=rot,psf_offsets_det= (0.48,0.0), phi_waves=0.5*np.random.normal(0,1.0, 7)/14.0)   # c. rotation (zero on non-zero defined by rot), non-zero psf_offsets, non-zero pistons
+    #std dev 1, 7 holes, diffraction-limited @ 2um we're at 4um
+    _pistons_w = 0.5 * np.random.normal(0,1.0, 7) / 14.0
 
-    
+    simulate_data(affine2d=aff, psf_offset_det=_psf_offset_det, pistons_w=_pistons_w)
+
+    #Tests specific to analyzing data simulated with rot=2.0 deg, psf offsets (0.48, 0.0) and pistons in waves = pistons_w - pistons_w.mean() where pistons_w = 0.5 * np.random.normal(0,1.0, 7) / 14.0
+
+    args_odd_fov = [[None, (0.0,0.0), None, _rotsearch_d],
+            [None, (0.0,0.0), (-0.5199,0.0), _rotsearch_d],
+            [None, (0.48,0.0), None, _rotsearch_d],
+            [aff,(0.0,0.0),None, None],
+            [None, (0.48,0.0), (-0.5199,0.0), _rotsearch_d],
+            [aff, (0.48,0.0), (-0.5199,0.0), _rotsearch_d],
+            ]
+
+    args_even_fov= [[None, (0.0,0.0), None, _rotsearch_d],
+            [None, (0.0,0.0), (-0.01983, -0.4998), _rotsearch_d],
+            [None, (0.48,0.0), None, _rotsearch_d],
+            [aff,(0.0,0.0),None, None],
+            [None, (0.48,0.0), (-0.01983, -0.4998), _rotsearch_d],
+            [aff, (0.48,0.0), (-0.01983, -0.4998), _rotsearch_d],
+            ]
+
+    np.set_printoptions(formatter={'float': lambda x: '{:+.2e}'.format(x)}, linewidth=80)
+
     for df in datafiles:
-        print("analyzing", df)
-        datafile = fits.getdata(df)
+        print("__main__: ")
+        np.set_printoptions(formatter={'float': lambda x: '{:+.2e}'.format(x)}, linewidth=80)
+        print("           analyzing", df)
+        data = fits.getdata(df)
 
-        """
-        *********  Note: When affine2d = None use rotsearch_d **********************************************
-        ********** when affine2d is created with user suppiled rotation, psf_offset_find_rotation and rotsearch_d are not used to find rotation  ************
-        ********** Put pistons back? TBD. set_pistons is a placeholder **************************************
+        if (data.shape[1] % 2) == 0:
+            args = args_even_fov
+        else:
+            args = args_odd_fov
 
-        Use forced psf_offset_ff with caution. Think whether the FOV is even or odd, where the brightest pixel is. If in the simulation you introduced no rotation,
-        no pistons, and an offset of 0.48 for odd FOV the center of the PSF stays inside the same pixel at 0.48 pixels from the center of the pixel. Fringefitter
-        uses offset from the center of the brightest pixel. Introducing a rotation (e.g 2 degrees) and some pistons moves the brightest pixel to the neoghboring pixel
-        on the right while keeping the PSF center at 0.48 in the original pixel. The correct offset for fringefitter is then the one measured from the center of
-        the brightest pixel on the right. This is -0.52.
-        """
-
-        # ***** THESE ARE DIFFERENT (NOT ALL) WAYS TO ANALYZE DATA THAT IS ROTATED BY SOME ANGLE (defined by rot for simulation in main), HAS PISTONS AND PSF_OFFSET OF (0.48, 0.0) *****
-        # ***** Use [1], [3], [4], [5], [6], [7] to analyze data odd fov data simulated by 'c'.
-        #If FOV is even and you introduced an offset of (0.48,0.0) in the simulation psf_offset_ff=(-0.5199,0.0) will not work. Update if you use even fov."
-
-        #[1]
-        #_aff, _psf_offset_ff, _psf_offset_r,_pistons = analyze_data(df, affine2d = None, psf_offset_find_rotation=(0.0,0.0), psf_offset_ff=None, rotsearch_d = _rotsearch_d, set_pistons = None)
-
-        #[2]
-        #_aff, _psf_offset_ff, _psf_offset_r, _pistons = analyze_data(df, affine2d = None, psf_offset_find_rotation=(0.0,0.0), psf_offset_ff=(0.48,0.0), rotsearch_d = _rotsearch_d, set_pistons = None)
-
-        #[3]
-        #_aff, _psf_offset_ff, _psf_offset_r, _pistons = analyze_data(df, affine2d = None, psf_offset_find_rotation=(0.0,0.0), psf_offset_ff=(-0.5199,0.0), rotsearch_d = _rotsearch_d, set_pistons = None)
-
-        #[4]
-        _aff, _psf_offset_ff, _psf_offset_r, _pistons = analyze_data(df, affine2d = None, psf_offset_find_rotation=(0.48,0.0), psf_offset_ff=None, rotsearch_d = _rotsearch_d, set_pistons = None)
-
-        #[5]
-        #_aff, _psf_offset_ff, _psf_offset_r, _pistons = analyze_data(df, affine2d = aff, psf_offset_find_rotation=(0.0,0.0), psf_offset_ff=None, rotsearch_d = None, set_pistons = None)
-
-        #[6]
-        #_aff, _psf_offset_ff, _psf_offset_r, _pistons = analyze_data(df, affine2d = None, psf_offset_find_rotation=(0.48,0.0), psf_offset_ff=(-0.5199,0.0), rotsearch_d = _rotsearch_d, set_pistons = None)
-
-        #[7]
-        #_aff, _psf_offset_ff, _psf_offset_r, _pistons = analyze_data(df, affine2d = aff, psf_offset_find_rotation=(0.48,0.0), psf_offset_ff=(-0.5199,0.0), rotsearch_d = _rotsearch_d, set_pistons = None)
-
-        print("/====affine used=========/")
-        _aff.show_rot()
-
-        print("/=====psf_offset used to find rotation====/")
-        print("***** NOTE: psf offset used to find rotation is not used when affine2d is provided by the user. *****")
-        print(_psf_offset_r,"\n")
-        print("/=====psf_offset used by fringefitter====/\n",_psf_offset_ff)
-        
-        
-        
-    print("/=====input affine==========/")
-    affine2d_in.show_rot()
-    print("/=====input psf_offset=======/\n", psf_offsets_in)
-    #print("/=====input pistons/r=======/\n",pistons_in*2*np.pi/4.3e-6)
-    utils.compare_pistons(pistons_in*2*np.pi/4.3e-6,_pistons)
-    print("Examine the residuals in", fitsimdir, "\n")
+        for i,j in enumerate(args):
+            print("Analysis parameters set:",i, "Affine2d", j[0], "psf_offset_find_rotation", j[1],"psf_offset_ff", j[2], "rotsearch_d",j[3])
+            _aff, _psf_offset_r, _psf_offset_ff, fringepistons = analyze_data(df,i, affine2d=j[0],
+                                                      psf_offset_find_rotation = j[1], psf_offset_ff = j[2],
+                                                      rotsearch_d=j[3])
+            print("  rotation search deg             ",_rotsearch_d)
+            np.set_printoptions(formatter={'float': lambda x: '{:+.2e}'.format(x)}, linewidth=80)
+            print("  affine rot used                 ", _aff.name, )
+            np.set_printoptions(formatter={'float': lambda x: '{:+.3f}'.format(x)}, linewidth=80)
+            print("  input psf offsets               ", np.array(_psf_offset_det))
+            print("  psf offset used to find rotation", np.array(_psf_offset_r))
+            print("  psf offset used by fringefitter ", np.array(_psf_offset_ff))
+            utils.compare_pistons(2*np.pi*(_pistons_w- _pistons_w.mean()), fringepistons)
+            print("implaneia output in: ", fitsimdir, "\n")
+ 

--- a/nrm_analysis/nrm_core.py
+++ b/nrm_analysis/nrm_core.py
@@ -159,14 +159,14 @@ class FringeFitter:
 
     def save_output(self, slc, nrm):
         # cropped & centered PSF
-        datapeak = self.ctrd.max()
+        self.datapeak = self.ctrd.max()
         #TBD: Keep only n_*.fits files after testing is done and before doing ImPlaneIA delivery
         if self.save_txt_only==False:
             fits.PrimaryHDU(data=self.ctrd, \
                     header=self.scihdr).writeto(self.savedir+\
                     self.sub_dir_str+"/centered_{0}.fits".format(slc), \
                     overwrite=True)
-            fits.PrimaryHDU(data=self.ctrd/datapeak, \
+            fits.PrimaryHDU(data=self.ctrd/self.datapeak, \
                     header=self.scihdr).writeto(self.savedir+\
                     self.sub_dir_str+"/n_centered_{0}.fits".format(slc), \
                     overwrite=True)
@@ -176,13 +176,13 @@ class FringeFitter:
             fits.PrimaryHDU(data=nrm.residual).writeto(self.savedir+\
                         self.sub_dir_str+"/residual_{0:02d}.fits".format(slc), \
                         overwrite=True)
-            fits.PrimaryHDU(data=nrm.residual/datapeak).writeto(self.savedir+\
+            fits.PrimaryHDU(data=nrm.residual/self.datapeak).writeto(self.savedir+\
                         self.sub_dir_str+"/n_residual_{0:02d}.fits".format(slc), \
                         overwrite=True)
             modelhdu.writeto(self.savedir+\
                         self.sub_dir_str+"/modelsolution_{0:02d}.fits".format(slc),\
                         overwrite=True)
-            fits.PrimaryHDU(data=model/datapeak, \
+            fits.PrimaryHDU(data=model/self.datapeak, \
                     header=modelhdu.header).writeto(self.savedir+\
                     self.sub_dir_str+"/n_modelsolution_{0:02d}.fits".format(slc), \
                     overwrite=True)
@@ -325,7 +325,7 @@ def fit_fringes_single_integration(args):
         print("**** image_center for information, not used",image_center)
         print(">>>> nrm_core: centroid offsets {0} from utils.centroid() <<<<".format(centroid))
         print(">>>> nrm_core: center of light in array coords (ds9) {0} <<<<".format(image_center))
-        nrm.xpos = centroid[1]  # flip 0 and 1 to convert 
+        nrm.xpos = centroid[1]  # flip 0 and 1 to convert
         nrm.ypos = centroid[0]  # flip 0 and 1
         print(">>>> nrm_core.fit_image(): refslice 6 lines commented out cf LG+ <<<<")
         print("\n**** nrm.core.fit_fringes_single_integration: FINDING PSF OFFSET...    previous <<HOLD_CENTERING>> False")


### PR DESCRIPTION
It would be helpful to save screen output from each test in an ascii file.
The fits files are saved in fitsimdir+test*+all_effects_data_mir folders. We can save the text files here.