### PR TITLE
Trim ref pix

### DIFF
--- a/nrm_analysis/InstrumentData.py
+++ b/nrm_analysis/InstrumentData.py
@@ -504,7 +504,9 @@ class NIRISS:
         # for single slice data, need to read as 3D (1, npix, npix)
         # for utr data, need to read as 3D (ngroup, npix, npix)
         fitsfile = fits.open(fn)
-        scidata=fitsfile[1].data
+        print("Reading data and trimming 4 rows of reference pixels...")
+        scidata=fitsfile[1].data[:,4:, :]
+        print(scidata.shape)
         prihdr=fitsfile[0].header
         scihdr=fitsfile[1].header
         self.updatewithheaderinfo(prihdr, scihdr) # mirage header or MAST header

--- a/nrm_analysis/misctools/utils.py
+++ b/nrm_analysis/misctools/utils.py
@@ -498,7 +498,7 @@ def center_imagepeak(img, r='default', cntrimg = True, verbose=False):
         Cropped to place the brightest pixel at the center of the img array
 
     """
-    peakx, peaky, h = min_distance_to_edge(img, cntrimg=cntrimg)
+    peakx, peaky, h = min_distance_to_edge(img)
     if r == 'default':
         r = h.copy()
     else:
@@ -512,7 +512,7 @@ def center_imagepeak(img, r='default', cntrimg = True, verbose=False):
     return cropped
 
 
-def min_distance_to_edge(img, cntrimg = True, verbose=False):
+def min_distance_to_edge(img, cntrimg = False, verbose=False):
     """Return pixel distance to closest detector edge.
 
     Parameters


### PR DESCRIPTION
Updated InstrumentData.py so that it trims bottom 4 rows of reference pixels. Updated utils.py so that it works with data for which the brightest pixel of the PSF is not located near the center of the array. e.g. POS 2, 3 and 4