### PR TITLE
Oifits tweaks

### DIFF
--- a/nrm_analysis/InstrumentData.py
+++ b/nrm_analysis/InstrumentData.py
@@ -753,8 +753,9 @@ class NIRISS:
         if pa != 0.0:
             v2 = mask_ctrs[:,0]
             v3 = mask_ctrs[:,1]
-            #v2_rot = v3*np.cos(np.deg2rad(pa)) - v2*np.sin(np.deg2rad(pa))
-            #v3_rot = v3*np.sin(np.deg2rad(pa)) + v2*np.cos(np.deg2rad(pa))
+            # clockwise rotation
+            v2_rot = v3*np.cos(np.deg2rad(pa)) + v2*np.sin(np.deg2rad(pa))
+            v3_rot = -v3*np.sin(np.deg2rad(pa)) + v2*np.cos(np.deg2rad(pa))
             ctrs_rot = np.zeros(mask_ctrs.shape)
             ctrs_rot[:,0] = v2_rot
             ctrs_rot[:,1] = v3_rot

--- a/nrm_analysis/InstrumentData.py
+++ b/nrm_analysis/InstrumentData.py
@@ -638,10 +638,13 @@ class NIRISS:
 
         np.set_printoptions(precision=5, suppress=True, linewidth=160, 
                             formatter={'float': lambda x: "%10.5f," % x})
+        print("self.mask.ctrs: \n", self.mask.ctrs)
+        # rotate mask hole center coords by PAV3 # RAC 2021
+        ctrs_sky = self.mast2sky()
+        print("new ctrs: \n", ctrs_sky)
         # Sydney oif coords switch... slow but sure this time!  (I hope...)
-        # print("self.mask.ctrs: \n", self.mask.ctrs)
-        stax_oif = self.mask.ctrs[:,1].copy()  * -1
-        stay_oif = self.mask.ctrs[:,0].copy()  * -1
+        stax_oif =  ctrs_sky[:,1].copy()  * -1
+        stay_oif =  ctrs_sky[:,0].copy()  * -1
         # print("stax_oif: ", stax_oif)
         # print("stay_oif: ", stay_oif)
         oifctrs = np.zeros(self.mask.ctrs.shape)
@@ -737,6 +740,28 @@ class NIRISS:
                  'JUMP_DET':   self.bpval['JUMP_DET'],
                  'DROPOUT':    self.bpval['DROPOUT'],
         }
+
+    def mast2sky(self):
+        """
+        Rotate hole center coordinates by the V3 position angle from north in degrees (PAV3)
+        Hole center coords are in the V2, V3 plane in meters.
+        Return rotated coordinates to be put in info4oif_dict.
+        implane2oifits.ObservablesFromText uses these to calculate baselines.
+        """
+        pa = self.pa
+        mask_ctrs = self.mask.ctrs
+        if pa != 0.0:
+            v2 = mask_ctrs[:,0]
+            v3 = mask_ctrs[:,1]
+            #v2_rot = v3*np.cos(np.deg2rad(pa)) - v2*np.sin(np.deg2rad(pa))
+            #v3_rot = v3*np.sin(np.deg2rad(pa)) + v2*np.cos(np.deg2rad(pa))
+            ctrs_rot = np.zeros(mask_ctrs.shape)
+            ctrs_rot[:,0] = v2_rot
+            ctrs_rot[:,1] = v3_rot
+        else:
+            ctrs_rot = mask_ctrs
+        return ctrs_rot
+
 
 class NIRC2:
     def __init__(self, reffile, **kwargs):

--- a/nrm_analysis/misctools/implane2oifits.py
+++ b/nrm_analysis/misctools/implane2oifits.py
@@ -256,6 +256,7 @@ class ObservablesFromText():
                 print(key)
         pfd.close()
         self.ctrs = self.info4oif_dict['ctrs']
+        self.pa = self.info4oif_dict['pa']
 
         """   seexyz.py
         Sydney oifitx oi_array:
@@ -780,7 +781,9 @@ def observable2dict(nrm, nrm_c=False, display=False):
                     'PSCALE': info4oif['pscale_mas'],
                     'STAXY': info4oif['ctrs'],
                     'ISZ': 77,  # size of the image needed (or fov)
-                    'NFILE': 0}
+                    'NFILE': 0,
+                    'PA': info4oif['pa']
+                    }
            }
 
     if display:
@@ -883,9 +886,7 @@ def calib_dicts(dct_t, dct_c):
     calib_dict['OI_VIS2']['VIS2ERR'] = sqverr_out
     calib_dict['OI_VIS']['VISAMPERR'] = vaerr_out
     # preserve the name of the calibrator star
-    calname = dct_c['info']['OBJECT']
-    calib_dict['info']['CALIB'] = calname
-
+    calib_dict['info']['CALIB'] = dct_c['info']['OBJECT']
 
     return calib_dict
 

--- a/nrm_analysis/misctools/oifits.py
+++ b/nrm_analysis/misctools/oifits.py
@@ -166,6 +166,7 @@ def save(dic, filename=None, oifprefix=None, datadir=None, verbose=False):
     hdu.header['FILT'] = dic['info']['FILT']
     hdu.header['ARRNAME'] = dic['info']['ARRNAME'] # Anand 9/2020
     hdu.header['MASK'] = dic['info']['ARRNAME'] # Anand 9/2020
+    hdu.header['PA'] = dic['info']['PA'] # RC 1/2021
     # name of calibrator if applicable. RC 1/2021
     try:
         hdu.header['CALIB'] = dic['info']['CALIB']
@@ -525,6 +526,10 @@ def load(filename, target=None, ins=None, mask=None, include_vis=True):
         dic['info']['INSMODE'] = hdr['INSMODE']
     except KeyError:
         dic['info']['INSMODE'] = None
+    try:
+        dic['info']['PA'] = hdr['PA']
+    except KeyError:
+        dic['info']['PA'] = None
 
     for hdu in fitsHandler[1:]:
         # RAC 9/2020


### PR DESCRIPTION
NRM hole center coordinates are rotated by the position angle of the observation WRT north, i.e. PAV3 for JWST. This does not modify the instrument object, but baselines are calculated using these equatorial coords when written out to OIFITS. This was done so that CANDID, which assumes equatorial coordinates, would produce binary companion position angle measured from north. Also, PA (PAV3) is now written out to the primary header of the OIFITS.