### PR TITLE
first pass good catname done

### DIFF
--- a/nrm_analysis/InstrumentData.py
+++ b/nrm_analysis/InstrumentData.py
@@ -696,11 +696,15 @@ class NIRISS:
         info4oif_dict['lam_w'] = self.lam_w
         info4oif_dict['lam_bin'] = self.lam_bin
 
-        # Target information
-        self.objname =  ph["TARGNAME"]
-        # 'ABDor' or 'AB Dor' work. Do not use '-' in aptx proposal name
-        # self.objname =  "ABDor"; info4oif_dict['objname'] = self.objname 
-        self.objname = self.objname.replace('-',''); info4oif_dict['objname'] = self.objname
+        # Target information - 5/21 targname UNKNOWN in nis019 rehearsal data
+        # Name in the proposal always non-trivial, targname still UNKNOWN...:
+        if ph["TARGNAME"] == 'UNKNOWN': objname = ph['TARGPROP']
+        else: objname = ph['TARGNAME'] # allegedly apt name for archive, standard form
+        #
+        # if target name has confusing-to-astroquery dash
+        self.objname =  objname.replace('-', ' '); info4oif_dict['objname'] = self.objname
+        # AB Dor, ab dor, AB DOR,  ab  dor are all acceptable.
+        #
         self.ra = ph["TARG_RA"]; info4oif_dict['ra'] = self.ra
         self.dec = ph["TARG_DEC"]; info4oif_dict['dec'] = self.dec
 


### PR DESCRIPTION
For AB-Dor (targprop) or UNKNOWN (targname) I fix the UNKNOWN to be targprop's value, then address dashes.
InstrumentData.objname is changed to 
OBJECT  = 'AB DOR  '
but I notice that there's a header  CALIB   = 'AB DOR  '  in the raw oifits file also.  Maybe it should not be there in raw oif's?

The same with HD-37093 in the calints fits files, the relevant oif headers are:
OBJECT  = 'HD 37093'  
CALIB   = 'HD 37093' 

In passing - not urgent:
I believe the oif standard keyword is ARRNAME, but our oif's also have MASK (redundantly, same value).  Next oif tweak could delete MASK (which may need our oifits writer to look for ARRNAME instead of MASK in the info dictionary..
ARRNAME = 'g7s6    ' 
MASK    = 'g7s6    '      
                                                  