### PR TITLE
Update InstrumentData.py

### DIFF
--- a/nrm_analysis/InstrumentData.py
+++ b/nrm_analysis/InstrumentData.py
@@ -447,6 +447,8 @@ class NIRISS:
             self.throughput = utils.trim_webbpsf_filter(self.filt, specbin=lam_bin[self.filt])
         except:
             self.throughput = utils.tophatfilter(lam_c[self.filt], lam_w[self.filt], npoints=11)
+            
+        self.throughput = np.array(self.throughput)
 
         try:
             self.wls = [utils.combine_transmission(self.throughput, src), ]


### PR DESCRIPTION
I found an error while running AMI notebooks:

```
FIRSTFEW 5 OVERSAMPLE 7

Analyzing
    0 jw01093001001_01101_00005_nis_calints F480M ABDOR ABDOR
5
InstrumentData.NIRISS: use bad pixel DQ extension data False
InstrumentData.NIRISS: analysing firstfew=5 slices
InstrumentData.NIRISS:  *** WARNING *** InstrumentData: Top Hat filter being used
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
/var/folders/b7/t7k94wx54xb6pckfcg1jxv5r0001_3/T/ipykernel_45583/3320212334.py in <module>
     24     usebp=False
     25 
---> 26     main(fitsimdir=datasuperdir,
     27          ifn=fnmir,
     28          oversample=OVERSAMPLE,

/var/folders/b7/t7k94wx54xb6pckfcg1jxv5r0001_3/T/ipykernel_45583/2231761077.py in main(fitsimdir, ifn, oversample, mnem, firstfew, verbose, usebp)
     92         print("main: fitsimdir", fitsimdir)
     93 
---> 94     aff, psf_offset_r, psf_offset_ff, fringepistons = raw_observables(ifn, fitsimdir,
     95                                                                       oversample=oversample,
     96                                                                       mnem=mnem,

/var/folders/b7/t7k94wx54xb6pckfcg1jxv5r0001_3/T/ipykernel_45583/2231761077.py in raw_observables(fitsfn, fitsimdir, affine2d, psf_offset_find_rotation, psf_offset_ff, rotsearch_d, set_pistons, oversample, mnem, firstfew, usebp, verbose)
     54 
     55     print(firstfew)
---> 56     niriss = InstrumentData.NIRISS(fobj[0].header['FILTER'],
     57                                    usebp=usebp,
     58                                    #bpexist=False,

~/miniconda3/envs/niriss_ami/lib/python3.8/site-packages/nrm_analysis/InstrumentData.py in __init__(self, filt, objname, src, out_dir, chooseholes, affine2d, bandpass, nbadpix, usebp, firstfew, **kwargs)
    438         # Weighted mean wavelength in meters, etc, etc "central wavelength" for the filter:
    439         from scipy.integrate import simps
--> 440         self.lam_c[self.filt] = (self.throughput[:,1] * self.throughput[:,0]).sum() / self.throughput[:,0].sum()
    441         area = simps(self.throughput[:,0], self.throughput[:,1])
    442         ew = area / self.throughput[:,0].max() # equivalent width

TypeError: list indices must be integers or slices, not tuple
```